### PR TITLE
Update tea times - from the Master

### DIFF
--- a/tea_timer.py
+++ b/tea_timer.py
@@ -14,12 +14,12 @@ parser.add_argument("-t", "--type", help="The type of tea to brew", type=str, ch
 args = parser.parse_args()
 
 teas = {
-	'white': (175, 5),
-	'green': (175, 1),
-	'oolong': (195, 3),
-	'black': (195, 3),
-	'rooibos': (208, 6),
-	'herbal': (208, 6),
+	'white': (160, 3),
+	'green': (175, 3),
+	'oolong': (185, 3),
+	'black': (200, 4),
+	'pu-erh': (205, 3),
+	'herbal': (212, 6),
 }
 
 


### PR DESCRIPTION
All of these assumptions that the tea leaves will only be used for a single steeping.

White tea does not need to be steeped for 5 minutes, nor at 175 deg. It is the least processed of all teas, and thus is the most susceptible to improper steeping when water temp is too hot, or for too long.

Boost green tea to 3 min.

Add pu-erh tea times (it's a separate category)

Rooibos is an herbal tea, so remove that.

General time changes otherwise.